### PR TITLE
Add Alibaba cloud mirror

### DIFF
--- a/Mirrors.masterlist
+++ b/Mirrors.masterlist
@@ -210,6 +210,16 @@ Location: Vinnytsia DTEL-IX
 Sponsor: IP-Connect.info
 IPv6: yes
 
+Site: mirrors.aliyun.com
+Type: Secondary
+Grml-http: grml/
+Grml-https: grml/
+Maintainer: Alibaba cloud mirror <ali-yum@alibaba-inc.com>
+Country: CN China
+Location: Hangzhou
+Sponsor: Alibaba cloud
+IPv6: yes
+
 Site: tw1.mirror.blendbyte.net
 Type: Secondary
 Grml-http: grml/


### PR DESCRIPTION
Alibaba is the largest cloud computing service provider in China. Alibaba cloud's open source image site provides services for the largest number of developers in China. For example, CentOS downloads more than 400 million times a day and Ubuntu downloads more than 30 million times a day.