### PR TITLE
add rsync to and remove ftp from ftp.fau.de

### DIFF
--- a/Mirrors.masterlist
+++ b/Mirrors.masterlist
@@ -54,7 +54,7 @@ IPv6: yes
 Site: ftp.fau.de
 Type: Secondary
 Grml-http: grml/
-Grml-ftp: grml/
+Grml-rsync: grml/
 Maintainer: RRZE FTP-Admins <rrze-ftp-admins@fau.de>
 Country: DE Germany
 Location: Erlangen


### PR DESCRIPTION
FTP on ftp.fau.de was disabled yesterday, so remove the ftp-url from grmls mirrorlist.
On the other hand, rsync access been available for years, so lets add that.