### PR TITLE
Drop mirror.serverion.com

### DIFF
--- a/Mirrors.masterlist
+++ b/Mirrors.masterlist
@@ -188,17 +188,6 @@ Location: Vienna
 Sponsor: Alwyzon https://www.alwyzon.com/
 IPv6: yes
 
-Site: mirror.serverion.com
-Type: Secondary
-Grml-http: grml/
-Grml-ftp: grml/
-Grml-rsync: grml/
-Maintainer: Serverion.com <mirror@serverion.com>
-Country: NL Netherlands
-Location: Zoetermeer, NL
-Sponsor: Serverion B.V.
-IPv6: yes
-
 Site: mirror.akardam.net
 Type: Secondary
 Grml-http: grml/


### PR DESCRIPTION
The mirror has mirror age of 16 hours and only has a small part of our latest 2025.05 release files, so drop the mirror until the mirror is up2date again.

FYI @descapital - we're happy to revert this again once the mirror is in sync again