### PR TITLE
Drop outdated mirrors for 2025.08 release

### DIFF
--- a/Mirrors.masterlist
+++ b/Mirrors.masterlist
@@ -188,17 +188,6 @@ Location: Vienna
 Sponsor: Alwyzon https://www.alwyzon.com/
 IPv6: yes
 
-Site: mirror.serverion.com
-Type: Secondary
-Grml-http: grml/
-Grml-ftp: grml/
-Grml-rsync: grml/
-Maintainer: Serverion.com <mirror@serverion.com>
-Country: NL Netherlands
-Location: Zoetermeer, NL
-Sponsor: Serverion B.V.
-IPv6: yes
-
 Site: mirror.akardam.net
 Type: Secondary
 Grml-http: grml/

--- a/Mirrors.masterlist
+++ b/Mirrors.masterlist
@@ -134,18 +134,6 @@ Location: Vinnytsia
 Sponsor: IP-Connect.vn.ua
 IPv6: yes
 
-Site: grml.ip-connect.info
-Type: Secondary
-Grml-http: /
-Grml-https: /
-Grml-ftp: mirror/grml/
-Grml-rsync: grml/
-Maintainer: IP-Connect mirror admin <mirrors@ip-connect.info>
-Country: UA Ukraine
-Location: Vinnytsia DTEL-IX
-Sponsor: IP-Connect.info
-IPv6: yes
-
 Site: mirrors.aliyun.com
 Type: Secondary
 Grml-http: grml/

--- a/Mirrors.masterlist
+++ b/Mirrors.masterlist
@@ -111,17 +111,6 @@ Location: Amsterdam
 Sponsor: Triple https://www.wearetriple.com/
 IPv6: yes
 
-Site: mirror.koddos.net
-Type: Secondary
-Grml-http: grml/
-Grml-https: grml/
-Grml-rsync: grml/
-Maintainer: Mirror Admin <mirror@koddos.net>
-Country: NL Netherlands
-Location: Dronten
-Sponsor: KoDDoS https://koddos.net
-IPv6: yes
-
 Site: mirror-hk.koddos.net
 Type: Secondary
 Grml-http: grml/


### PR DESCRIPTION
* Drop grml.ip-connect.info /cc @mirrors-IP-Connect-info
* Drop mirror.koddos.net /cc @koddos
* Drop mirror.serverion.com  /cc @descapital

FYI, happy to re-enable mirrors whenever they are in sync again, but as long as they don't provide the new 2025.08 files, we can't keep them enabled