### PR TITLE
Disable failing mirrors.aliyun.com

### DIFF
--- a/Mirrors.masterlist
+++ b/Mirrors.masterlist
@@ -134,16 +134,6 @@ Location: Vinnytsia
 Sponsor: IP-Connect.vn.ua
 IPv6: yes
 
-Site: mirrors.aliyun.com
-Type: Secondary
-Grml-http: grml/
-Grml-https: grml/
-Maintainer: Alibaba cloud mirror <ali-yum@alibaba-inc.com>
-Country: XX Global CDN
-Location: Hangzhou
-Sponsor: Alibaba cloud
-IPv6: no
-
 Site: mirror.twds.com.tw
 Type: Secondary
 Grml-http: grml/


### PR DESCRIPTION
In Debian's bug report [#1121979](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1121979) it was brought up that update-grml-rescueboot fails. As it turned out, mirrors.aliyun.com doesn't seem to be working as expected:

```
    | % wget --verbose -O /dev/null https://download.grml.org/grml-full-2025.08-amd64.iso
    | [...]
    | --2025-12-08 08:13:52--  https://mirrors.aliyun.com/grml/grml-full-2025.08-amd64.iso
    | Resolving mirrors.aliyun.com (mirrors.aliyun.com)... 47.246.49.203, 47.246.49.204, 47.246.49.187, ...
    | Connecting to mirrors.aliyun.com (mirrors.aliyun.com)|47.246.49.203|:443... connected.
    | HTTP request sent, awaiting response... 302 Moved Temporarily
    | Location: http://iso-osm.mirrors.aliyuncs.com/grml/grml-full-2025.08-amd64.iso [following]
    | --2025-12-08 08:13:53--  http://iso-osm.mirrors.aliyuncs.com/grml/grml-full-2025.08-amd64.iso
    | Resolving iso-osm.mirrors.aliyuncs.com (iso-osm.mirrors.aliyuncs.com)... 8.132.237.172
    | Connecting to iso-osm.mirrors.aliyuncs.com (iso-osm.mirrors.aliyuncs.com)|8.132.237.172|:80... failed: Connection refused.
```

I can also verify from different systems in AT + DE:

```
    | % wget --verbose -O /dev/null https://mirrors.aliyun.com/grml/grml-full-2025.08-amd64.iso
    | --2025-12-08 18:32:57--  https://mirrors.aliyun.com/grml/grml-full-2025.08-amd64.iso
    | Resolving mirrors.aliyun.com (mirrors.aliyun.com)... 163.181.58.175, 163.181.58.172, 163.181.58.177, ...
    | Connecting to mirrors.aliyun.com (mirrors.aliyun.com)|163.181.58.175|:443... connected.
    | HTTP request sent, awaiting response... 302 Moved Temporarily
    | Location: http://iso-osm.mirrors.aliyuncs.com/grml/grml-full-2025.08-amd64.iso [following]
    | --2025-12-08 18:32:59--  http://iso-osm.mirrors.aliyuncs.com/grml/grml-full-2025.08-amd64.iso
    | Resolving iso-osm.mirrors.aliyuncs.com (iso-osm.mirrors.aliyuncs.com)... 8.132.237.172
    | Connecting to iso-osm.mirrors.aliyuncs.com (iso-osm.mirrors.aliyuncs.com)|8.132.237.172|:80... connected.
    | HTTP request sent, awaiting response... 502 Bad Gateway
    | 2025-12-08 18:32:59 ERROR 502: Bad Gateway.
```

Until we know it's working as expected, drop mirrors.aliyun.com from our mirror list.

FTR: this a basically a revert of https://github.com/grml/grml-mirrors/pull/16