### PR TITLE
ipserverone: drop broken rsync one

### DIFF
--- a/Mirrors.masterlist
+++ b/Mirrors.masterlist
@@ -209,7 +209,6 @@ Site: mirrors.ipserverone.com
 Type: Secondary
 Grml-http: grml/
 Grml-https: grml/
-Grml-rsync: grml/
 Maintainer: IPS1 Support <support@ipserverone.com>
 Country: MY Malaysia
 Location: Cyberjaya


### PR DESCRIPTION
The ipserverone rsync mirror doesn't provide "grml":

```
  % rsync rsync://mirrors.ipserverone.com

  ==============================================================
     IP ServerOne Solution Sdn Bhd - Public Mirror
  ==============================================================

     💡 This is a public mirror,
	Please treat it nicely and use responsibly.

     🚀 Cloud Hosting, Backup & Storage Service Provider

     📌 Location: Malaysia

     🌐 https://www.ipserverone.com/

  ==============================================================

  almalinux       "AlmaLinux"
  centos-stream   "CentOS Stream"
  centos-vault    "CentOS Vault"
  debian          "Debian"
  debian-cd       "Debian CD"
  fedora          "Fedora"
  hbcd            "Hiren's BootCD"
  nvidia          "NVIDIA CUDA"
  rocky           "RockyLinux"
  ubuntu          "Ubuntu"
  ubuntu-releases "Ubuntu Releases"

  % rsync rsync://mirrors.ipserverone.com/grml/

  ==============================================================
     IP ServerOne Solution Sdn Bhd - Public Mirror
  ==============================================================

     💡 This is a public mirror,
	Please treat it nicely and use responsibly.

     🚀 Cloud Hosting, Backup & Storage Service Provider

     📌 Location: Malaysia

     🌐 https://www.ipserverone.com/

  ==============================================================

  @ERROR: Unknown module 'grml'
  rsync error: error starting client-server protocol (code 5) at main.c(1850) [Receiver=3.4.1]
```