### PR TITLE
leaseweb: drop rsync in de, us

### DIFF
--- a/Mirrors.masterlist
+++ b/Mirrors.masterlist
@@ -1,7 +1,6 @@
 Site: mirror.de.leaseweb.net
 Type: Secondary
 Grml-http: grml/
-Grml-rsync: grml/
 Maintainer: Jeffrey Kriegsman <mirror@leaseweb.com>
 Country: DE Germany
 Location: Frankfurt
@@ -21,7 +20,6 @@ IPv6: yes
 Site: mirror.us.leaseweb.net
 Type: Secondary
 Grml-http: grml/
-Grml-rsync: grml/
 Maintainer: Jeffrey Kriegsman <mirror@leaseweb.com>
 Country: US United States of America
 Location: Manassas, Virginia, PowerLoft DC


### PR DESCRIPTION
While all leaseweb mirrors offer rsync access, the de and us locations apparently get hammered and more often fail than not.