### PR TITLE
Remove smartmatch ~~ feature

### DIFF
--- a/bin/generate_mirror_map
+++ b/bin/generate_mirror_map
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use lib '/usr/share/perl5/';
-use experimental 'smartmatch';
+use List::Util qw(none);
 
 my $ipv6_only = 0;
 foreach my $arg (@ARGV) {
@@ -66,8 +66,8 @@ my $all_up_mirrors = [];
 
 # Find all "up" mirrors from Mirmon data
 foreach my $url ( keys %{$state} ) {
-	next unless $url ~~ @https_urls;
-	$mirror = $state -> { $url } ; # a Mirmon::Mirror object
+	next if none { $_ eq $url } @https_urls;
+	$mirror = $state -> { $url };  # a Mirmon::Mirror object
 	my ($time, $history) = split('-', $mirror->{state_history});
 	my $last_state = substr($history,-1,1);
 	next if $last_state eq 'f';  # skip down mirrors
@@ -103,14 +103,14 @@ if (!exists $mirror_regions->{'XX'} || !@{$mirror_regions->{'XX'}}) {
 	if (@{$secondary_plus_mirrors}) {
 		$mirror_regions->{'XX'} = [@{$secondary_plus_mirrors}];
 		$regions_hash->{'XX'} = 1;
-		push @regions, 'XX' unless 'XX' ~~ @regions;
+		push @regions, 'XX' if none { $_ eq 'XX' } @regions;
 	}
 
 	# fallback of fallback: if no SecondaryPlus mirrors are up, add any other available mirror
 	elsif (@{$all_up_mirrors}) {
 		$mirror_regions->{'XX'} = [$all_up_mirrors->[0]];  # Just take the first available
 		$regions_hash->{'XX'} = 1;
-		push @regions, 'XX' unless 'XX' ~~ @regions;
+		push @regions, 'XX' if none { $_ eq 'XX' } @regions;
 	}
 }
 


### PR DESCRIPTION
Deprecated by Perl, and at least Perl v5.40.1 in Debian already complains.

Supposed to be removed in Perl v5.42, although the deprecation process seems to be undergoing changes.

Closes: grml/grml-mirrors#47